### PR TITLE
Add proper padding to EC public key

### DIFF
--- a/oauth2/certs
+++ b/oauth2/certs
@@ -12,8 +12,8 @@
             "kty": "EC",
             "alg": "ES256",
             "kid": "26df",
-            "y": "xkUiCX5aPmZplJ5UVHk-DwWBywLEYcbweruF2qajDjU",
-            "x": "DFYYgpiQbaBtxtlCm1ocw26xc_6tQGukFRVYCTK2x9M",
+            "y": "xkUiCX5aPmZplJ5UVHk-DwWBywLEYcbweruF2qajDjU=",
+            "x": "DFYYgpiQbaBtxtlCm1ocw26xc_6tQGukFRVYCTK2x9M=",
             "crv": "P-256",
             "use": "sig"
         }


### PR DESCRIPTION
Not sure how this public key was generated, but the scitokens-admin-create-key does generate ec keys with proper padding.  Was this generated before that?

This broke scitokens-cpp.  Python isn't failing with it though, not sure why.